### PR TITLE
Migrate to audio_service for background playback

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:just_audio_background/just_audio_background.dart';
 import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
 import 'package:resonate/api/auth.dart';
@@ -14,13 +13,6 @@ import 'package:resonate/test_page.dart';
 import 'package:resonate/utils/time.dart';
 
 void main() async {
-  // https://pub.dev/packages/just_audio_background
-  // Requires more setup in .xml
-  await JustAudioBackground.init(
-    androidNotificationChannelId: 'com.ryanheise.bg_demo.channel.audio',
-    androidNotificationChannelName: 'Audio playback',
-    androidNotificationOngoing: true,
-  );
   WidgetsFlutterBinding.ensureInitialized();
   AppLogger.instance.init();
   // Logger.root.level = Level.ALL;

--- a/app/lib/services/player.dart
+++ b/app/lib/services/player.dart
@@ -3,7 +3,7 @@
 */
 import 'dart:async';
 
-import 'package:just_audio_background/just_audio_background.dart';
+import 'package:audio_service/audio_service.dart';
 import 'package:logging/logging.dart';
 import 'package:resonate/models/models.dart';
 import 'package:audio_session/audio_session.dart';
@@ -43,24 +43,24 @@ class PlayerProgress {
   final PlayerState playerState;
 
   double get percentProgress {
-    if (progressDuration == null || duration == null) {
+    if (progressDuration == null || duration == null || duration == Duration.zero) {
       return 0;
     }
-    return progressDuration!.inMilliseconds / duration!.inMilliseconds;
+    return progressDuration.inMilliseconds / duration!.inMilliseconds;
   }
 
   double get percentBuffered {
-    if (bufferedDuration == null || duration == null) {
+    if (bufferedDuration == null || duration == null || duration == Duration.zero) {
       return 0;
     }
-    return bufferedDuration!.inMilliseconds / duration!.inMilliseconds;
+    return bufferedDuration.inMilliseconds / duration!.inMilliseconds;
   }
 
   Duration get remainingDuration {
     if (progressDuration == null || duration == null) {
       return Duration.zero;
     }
-    return duration! - progressDuration!;
+    return duration! - progressDuration;
   }
 
   Duration calculateProgressDuration(double percent) {
@@ -85,148 +85,122 @@ class PlayerProgress {
 
 class PlayerService implements AbstractPlayerService {
   PlayerService() {
-    _player = justAudio.AudioPlayer();
     _stateStreamController = StreamController<PlayerState>.broadcast(
       onListen: () => state,
     );
     _persistentProgressStreamController =
         StreamController<PlayerProgress>.broadcast(onListen: () => progress);
-    // _setupProgressStream();
-    _player.playerStateStream.listen((_) => _onStateChange());
-    _player.processingStateStream.listen((_) => _onStateChange());
+
+    _init();
   }
 
-  late final StreamController<PlayerProgress>
-  _persistentProgressStreamController;
+  final Completer<ResonateAudioHandler> _handlerCompleter = Completer();
+  ResonateAudioHandler? _handler;
+
+  StreamSubscription? _playbackSubscription;
+  StreamSubscription? _progressSubscription;
+
+  Future<void> _init() async {
+    final handler = await AudioService.init(
+      builder: () => ResonateAudioHandler(),
+      config: const AudioServiceConfig(
+        androidNotificationChannelId: 'com.resonate.audio',
+        androidNotificationChannelName: 'Resonate Audio Playback',
+        androidNotificationOngoing: true,
+      ),
+    );
+
+    _playbackSubscription = handler.playbackState.listen((_) => _onStateChange());
+    _progressSubscription = handler.progress.listen((p) {
+      _persistentProgressStreamController.add(p);
+    });
+
+    _handler = handler;
+    _handlerCompleter.complete(handler);
+  }
+
+  late final StreamController<PlayerProgress> _persistentProgressStreamController;
   late final StreamController<PlayerState> _stateStreamController;
-  // StreamController<PlayerProgress>? _progressStreamController;
 
   @override
   void dispose() {
-    _player.dispose();
+    _playbackSubscription?.cancel();
+    _progressSubscription?.cancel();
     _stateStreamController.close();
     _persistentProgressStreamController.close();
-    // _progressStreamController?.close();
   }
 
   void _onStateChange() {
     var s = state;
     _log.info('onStateChange::$s');
-    _timer?.cancel();
-    switch (s) {
-      case PlayerState.init:
-      case PlayerState.paused:
-      case PlayerState.finished:
-        break;
-      case PlayerState.playing:
-      case PlayerState.loading:
-        _timer = Timer.periodic(Duration(seconds: 1), _onTick);
-        break;
-    }
     _stateStreamController.add(s);
-    _persistentProgressStreamController.add(progress);
   }
-
-  Timer? _timer;
-  void _onTick(_) {
-    // _progressStreamController?.add(progress);
-    _persistentProgressStreamController.add(progress);
-  }
-
-  // Future<bool> _setupProgressStream() async {
-  //   await _progressStreamController?.close();
-  //   _progressStreamController = StreamController<PlayerProgress>.broadcast(
-  //     onListen: () => progress,
-  //   );
-  //   return true;
-  // }
-
-  late final justAudio.AudioPlayer _player;
-
-  Duration? _episodeDuration;
-  String? _currentEpisodeId;
 
   @override
   Future<bool> load(Episode episode, {Duration? startDuration}) async {
     _log.info('load::${episode.audioUrl}');
-    // Set up the audio session speech category
     final session = await AudioSession.instance;
     await session.configure(const AudioSessionConfiguration.speech());
 
-    // There seems to be a bug, where if the player is not
-    // stopped before you call this, it will just play the
-    // same episode regardless of the audioSource.
-    if (_player.playing) {
-      _persistentProgressStreamController.add(progress);
-      await _player.stop();
-    }
-    _currentEpisodeId = episode.id;
-    _episodeDuration = await _player.setAudioSource(
-      justAudio.AudioSource.uri(
-        Uri.parse(episode.audioUrl),
-        tag: MediaItem(
-          id: episode.id,
-          title: episode.title,
-          duration: episode.duration,
-          // TODO(duncan): I need the podcast name here..
-          artUri: episode.imageUrl != '' ? Uri.parse(episode.imageUrl) : null,
-        ),
-      ),
-      initialPosition: startDuration,
-    );
-    // await _setupProgressStream();
-    // _player.play();
+    final handler = await _handlerCompleter.future;
+    await handler.loadEpisode(episode, startDuration: startDuration);
     return true;
   }
 
   @override
   Future<void> pause() async {
-    await _player.pause();
+    final handler = await _handlerCompleter.future;
+    await handler.pause();
   }
 
   @override
   Future<void> play() async {
-    await _player.play();
-  }
-
-  PlayerProgress _progress({bool switchingAudio = false}) {
-    return PlayerProgress(
-      episodeId: _currentEpisodeId ?? 'unknown',
-      progressDuration: _player.position,
-      bufferedDuration: _player.bufferedPosition,
-      duration: _episodeDuration,
-      playerState: state,
-    );
+    final handler = await _handlerCompleter.future;
+    await handler.play();
   }
 
   @override
   PlayerProgress get progress {
-    return _progress();
+    if (_handler == null) {
+       return PlayerProgress(
+         bufferedDuration: Duration.zero,
+         progressDuration: Duration.zero,
+         episodeId: 'unknown',
+         playerState: PlayerState.init,
+       );
+    }
+    return _handler!.currentProgress;
   }
 
   @override
   Future<void> seek(Duration duration) async {
-    await _player.seek(duration);
+    final handler = await _handlerCompleter.future;
+    await handler.seek(duration);
   }
 
   @override
   Future<void> stop() async {
-    await _player.stop();
+    final handler = await _handlerCompleter.future;
+    await handler.stop();
   }
 
   @override
   PlayerState get state {
-    switch (_player.processingState) {
-      case justAudio.ProcessingState.completed:
+    if (_handler == null) return PlayerState.init;
+    final playing = _handler!.playbackState.value.playing;
+    final processingState = _handler!.playbackState.value.processingState;
+
+    switch (processingState) {
+      case AudioProcessingState.completed:
         return PlayerState.finished;
-      case justAudio.ProcessingState.ready:
-        return _player.playerState.playing
-            ? PlayerState.playing
-            : PlayerState.paused;
-      case justAudio.ProcessingState.buffering:
-      case justAudio.ProcessingState.loading:
+      case AudioProcessingState.ready:
+        return playing ? PlayerState.playing : PlayerState.paused;
+      case AudioProcessingState.buffering:
+      case AudioProcessingState.loading:
         return PlayerState.loading;
-      case justAudio.ProcessingState.idle:
+      case AudioProcessingState.idle:
+        return PlayerState.init;
+      default:
         return PlayerState.init;
     }
   }
@@ -238,7 +212,118 @@ class PlayerService implements AbstractPlayerService {
 
   @override
   Stream<PlayerProgress> streamProgress() {
-    // return _progressStreamController!.stream;
     return _persistentProgressStreamController.stream;
+  }
+}
+
+class ResonateAudioHandler extends BaseAudioHandler with SeekHandler {
+  final _player = justAudio.AudioPlayer();
+  final _progressController = StreamController<PlayerProgress>.broadcast();
+
+  Stream<PlayerProgress> get progress => _progressController.stream;
+
+  ResonateAudioHandler() {
+    _player.playbackEventStream.listen((event) {
+      playbackState.add(_transformEvent(event));
+    });
+
+    _player.processingStateStream.listen((state) {
+       if (state == justAudio.ProcessingState.completed) {
+         playbackState.add(playbackState.value.copyWith(
+           processingState: AudioProcessingState.completed,
+         ));
+       }
+    });
+
+    _player.positionStream.listen((position) {
+      _progressController.add(currentProgress);
+    });
+  }
+
+  PlayerProgress get currentProgress {
+    return PlayerProgress(
+      episodeId: mediaItem.value?.id ?? 'unknown',
+      progressDuration: _player.position,
+      bufferedDuration: _player.bufferedPosition,
+      duration: _player.duration,
+      playerState: _state,
+    );
+  }
+
+  PlayerState get _state {
+    switch (_player.processingState) {
+      case justAudio.ProcessingState.completed:
+        return PlayerState.finished;
+      case justAudio.ProcessingState.ready:
+        return _player.playing ? PlayerState.playing : PlayerState.paused;
+      case justAudio.ProcessingState.buffering:
+      case justAudio.ProcessingState.loading:
+        return PlayerState.loading;
+      case justAudio.ProcessingState.idle:
+        return PlayerState.init;
+    }
+  }
+
+  Future<void> loadEpisode(Episode episode, {Duration? startDuration}) async {
+    final item = MediaItem(
+      id: episode.id,
+      album: episode.podcastId,
+      title: episode.title,
+      duration: episode.duration,
+      artUri: episode.imageUrl.isNotEmpty ? Uri.parse(episode.imageUrl) : null,
+      extras: {'audioUrl': episode.audioUrl},
+    );
+    mediaItem.add(item);
+
+    await _player.setAudioSource(
+      justAudio.AudioSource.uri(
+        Uri.parse(episode.audioUrl),
+      ),
+      initialPosition: startDuration,
+    );
+  }
+
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  @override
+  Future<void> stop() async {
+    await _player.stop();
+    await super.stop();
+  }
+
+  PlaybackState _transformEvent(justAudio.PlaybackEvent event) {
+    return PlaybackState(
+      controls: [
+        MediaControl.rewind,
+        if (_player.playing) MediaControl.pause else MediaControl.play,
+        MediaControl.stop,
+        MediaControl.fastForward,
+      ],
+      systemActions: const {
+        MediaAction.seek,
+        MediaAction.seekForward,
+        MediaAction.seekBackward,
+      },
+      androidCompactActionIndices: const [0, 1, 3],
+      processingState: const {
+        justAudio.ProcessingState.idle: AudioProcessingState.idle,
+        justAudio.ProcessingState.loading: AudioProcessingState.loading,
+        justAudio.ProcessingState.buffering: AudioProcessingState.buffering,
+        justAudio.ProcessingState.ready: AudioProcessingState.ready,
+        justAudio.ProcessingState.completed: AudioProcessingState.completed,
+      }[_player.processingState]!,
+      playing: _player.playing,
+      updatePosition: _player.position,
+      bufferedPosition: _player.bufferedPosition,
+      speed: _player.speed,
+      queueIndex: event.currentIndex,
+    );
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "2.13.0"
   audio_service:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: audio_service
       sha256: cb122c7c2639d2a992421ef96b67948ad88c5221da3365ccef1031393a76e044
@@ -648,14 +648,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.5"
-  just_audio_background:
-    dependency: "direct main"
-    description:
-      name: just_audio_background
-      sha256: "3900825701164577db65337792bc122b66f9eb1245ee47e7ae8244ae5ceb8030"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.1-beta.17"
   just_audio_platform_interface:
     dependency: transitive
     description:
@@ -732,10 +724,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1185,10 +1177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.3
   cookie_jar: ^4.0.8
-  just_audio_background: ^0.0.1-beta.17
+  audio_service: ^0.18.17
   vector_math: ^2.2.0
   universal_html: ^2.3.0
   universal_io: ^2.3.1


### PR DESCRIPTION
This change migrates the audio playback logic to the `audio_service` package, providing better flexibility for notification controls and background event handling. The implementation is localized within the `PlayerService` and maintains compatibility with the existing `AbstractPlayerService` interface.

---
*PR created automatically by Jules for task [10964201867918124915](https://jules.google.com/task/10964201867918124915) started by @dghwood*